### PR TITLE
FIX Don't clear results when loading the next page.

### DIFF
--- a/src/components/ApolloResults.vue
+++ b/src/components/ApolloResults.vue
@@ -1,6 +1,7 @@
 <template>
   <Results
     v-bind:loading="$apollo.loading"
+    v-bind:loadingNextPage="loadingNextPage"
     v-bind:results="allResults.edges || []"
     v-bind:error="error"
     v-bind:totalCount="totalCount"
@@ -25,6 +26,7 @@ import repoGroups from '../repos.json';
 
 type Data = {
   loading: boolean,
+  loadingNextPage: boolean,
   totalCount: number,
   allResults: SearchResultItemConnection,
   error: Error | undefined,
@@ -45,6 +47,7 @@ export default defineComponent({
   data() {
     return {
       loading: false,
+      loadingNextPage: false,
       totalCount: 0,
       allResults: {},
       error: undefined,
@@ -148,8 +151,9 @@ export default defineComponent({
   },
 
   methods: {
-    getMoreResults() {
-      this.$apollo.queries.allResults.fetchMore({
+    async getMoreResults() {
+      this.loadingNextPage = true;
+      await this.$apollo.queries.allResults.fetchMore({
         variables: {
           query: this.compositeQuery,
           pageCursor: this.allResults.pageInfo['endCursor'],
@@ -165,7 +169,8 @@ export default defineComponent({
           };
           return search;
         }
-      })
+      });
+      this.loadingNextPage = false;
     },
   },
 

--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="{ dark: isDark }">
     <!-- Loading -->
-    <div v-if="loading" class="btn loading apollo">
+    <div v-if="loading && !loadingNextPage" class="btn loading apollo">
       <vue-loaders name="ball-beat" color="#0071C4"></vue-loaders>
     </div>
 
@@ -22,7 +22,7 @@
       <div class="results__footer">
         <p class="results__count">Showing {{results.length}} of {{totalCount}}</p>
         <button v-if="hasMore" class="btn" v-bind:disabled="loading" @click="handleMoreResults">
-          <template v-if="!loading">Show More</template>
+          <template v-if="!loadingNextPage">Show More</template>
           <template v-else>Loading More</template>
         </button>
       </div>
@@ -46,6 +46,7 @@ import { defineComponent } from 'vue';
 export default defineComponent({
   props: {
     loading: Boolean,
+    loadingNextPage: Boolean,
     results: {
       type: Array,
       required: true


### PR DESCRIPTION
This was broken in https://github.com/silverstripe/github-issue-search-client/commit/8a0140b4656b150544f3546b32e3d5f53baea780

It looks like this was the original intention - but it wasn't working with the `loading && ( !results || results.length === 0)` condition for reasons discussed in the above linked commit.

This PR gives the best of both worlds - fresh queries always display a loading indicator (e.g. when swapping to a new tab for the first time), but new pages don't throw the user to the top of the page.

## Issue
- https://github.com/silverstripe/github-issue-search-client/issues/126