### PR TITLE
ENH Explicitly use OR and AND for GraphQL queries

### DIFF
--- a/src/components/ApolloResults.vue
+++ b/src/components/ApolloResults.vue
@@ -70,7 +70,7 @@ export default defineComponent({
         rfc: 'RFC', // search term
         easy: 'label:complexity/low',
         bugs: 'label:type/bug',
-        untriaged: 'is:open is:issue no:label',
+        untriaged: '(is:open AND is:issue AND no:label)',
       };
 
       return this.formData.mode ? queryModes[this.formData.mode] : '';
@@ -108,8 +108,8 @@ export default defineComponent({
       }
 
       const uniqueRepos = [...new Set(repos)]; // filter out duplicates
-
-      return uniqueRepos.map(repo => `repo:${repo}`).join(' ');
+      const queryString = uniqueRepos.map(repo => `repo:${repo}`).join(' OR ');
+      return `(${queryString})`;
     },
 
     sortQuery() {
@@ -151,7 +151,8 @@ export default defineComponent({
       if (!this.formData.communityOnly) {
         return '';
       }
-      return this.nonCommunityUsers.map(user => `-author:${user}`).join(' ');
+      const queryString = this.nonCommunityUsers.map(user => `-author:${user}`).join(' AND ');
+      return `(${queryString})`;
     },
 
     compositeQuery(): string {
@@ -163,7 +164,7 @@ export default defineComponent({
         this.repoQuery,
         this.sortQuery,
         this.authorQuery,
-      ].join(' ');
+      ].filter((item) => item !== null && item !== '').join(' AND ');
     },
 
     showShowMore() {

--- a/src/graphql/Search.js
+++ b/src/graphql/Search.js
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 export default gql`query($query:String!, $pageCursor:String) {
-  search(query:$query, type:ISSUE, first:15, after:$pageCursor) {
+  search(query:$query, type:ISSUE_ADVANCED, first:15, after:$pageCursor) {
     edges {
       node {
         ...on Issue {


### PR DESCRIPTION
GitHub is updating its API to use advanced search by default, so this commit prepares us for that change.

I have swapped from using `type:ISSUE` to `type:ISSUE_ADVANCED` because otherwise we got 0 results. It looks like `ISSUE_ADVANCED` is the advanced search. It comes from https://docs.github.com/en/graphql/reference/enums#searchtype which doesn't explain the difference.

I did try to update the REST API usage for commits and code search - code search is already failing due to insufficient permissions (we should probably remove it but that's a separate concern) and commit search started failing when I updated it. The error was "The search is longer than 256 characters" but given the existing search query is > 3000 characters already that error message is obviously a red herring. We don't use commit search much (if ever) so I've just left it as is.

## Issue

- https://github.com/silverstripe/github-issue-search-client/issues/165